### PR TITLE
Fixed a missing require

### DIFF
--- a/lib/jquery-tmpl-rails/jquery_tmpl_processor.rb
+++ b/lib/jquery-tmpl-rails/jquery_tmpl_processor.rb
@@ -1,3 +1,4 @@
+require 'sprockets'
 require 'sprockets/engines'
 require 'tilt'
 require 'action_view'


### PR DESCRIPTION
```
E, [2012-02-27T12:59:35.921161 #42445] ERROR -- : undefined method `register_engine' for Sprockets:Module (NoMethodError)
/Users/mtarnovan/.rvm/gems/ruby-1.9.3-p125@portfoleo/gems/jquery-tmpl-rails-0.1.1/lib/jquery-tmpl-rails/jquery_tmpl_processor.rb:26:in `<module:Sprockets>'
```
