### PR TITLE
Tilt required + Rails asset now recognized +support Regexp for template prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,26 @@ $.tmpl("templates/author", { name: "Jimmy" }).appendTo("#author");
 
 ## Configuration
 
-If the path to all of your templates have a common prefix that you prefer is not included in the template's name, you can set this option in `config/application.rb`:
+If the path to all of your templates have a common prefix that you prefer is not included in the template's name, you can set this option in an initializer such as `config/initializers/jquery_templates.rb`:
 
 ```ruby
-config.jquery_templates.prefix = "templates"
+JqueryTmplRails.configure do |config|
+  config.prefix = "templates"
+end
 ```
 
 That would change the previous example to this:
 
 ```javascript
 $.tmpl("author", { name: "Jimmy" }).appendTo("#author");
+```
+
+Note: If you want to use only the name of your file for the template name, you can do so:
+
+```ruby
+JqueryTmplRails.configure do |config|
+  config.prefix = /([^\/]*\/)*/
+end
 ```
 
 Happy templating!

--- a/jquery-tmpl-rails.gemspec
+++ b/jquery-tmpl-rails.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'rails', '>= 3.1.0'
+  s.add_dependency 'tilt', '~> 1.3.3'
   s.add_development_dependency 'rspec'
 end

--- a/lib/jquery-tmpl-rails/engine.rb
+++ b/lib/jquery-tmpl-rails/engine.rb
@@ -1,13 +1,36 @@
 require "active_support/ordered_options"
 
 module JqueryTmplRails
+
+  class << self
+    
+    def prefix=(pref)
+      if pref.is_a?(String) and pref.length > 0
+        pref = pref[1, pref.length - 1] if pref.start_with?("/")
+        pref += "/" unless pref.end_with?("/")
+      end
+      
+      @prefix = pref
+      
+      puts "prefix is now #{@prefix.inspect}"
+    end
+    
+    def prefix
+      @prefix || ""
+    end
+    
+    def configure
+      yield self
+      true
+    end
+    
+  end
+  
   class Railtie < Rails::Engine
     initializer "sprockets.jquery_templates", :after => "sprockets.environment", :group => :all do |app|
       next unless app.assets
-
+      
       app.assets.register_engine(".tmpl", JqueryTemplate)
-      app.config.jquery_templates = ActiveSupport::OrderedOptions.new
-      app.config.jquery_templates.prefix = ""
     end
   end
 end

--- a/lib/jquery-tmpl-rails/engine.rb
+++ b/lib/jquery-tmpl-rails/engine.rb
@@ -11,8 +11,6 @@ module JqueryTmplRails
       end
       
       @prefix = pref
-      
-      puts "prefix is now #{@prefix.inspect}"
     end
     
     def prefix

--- a/lib/jquery-tmpl-rails/jquery_template.rb
+++ b/lib/jquery-tmpl-rails/jquery_template.rb
@@ -21,8 +21,6 @@ module JqueryTmplRails
     private
     
     def template_name(scope)
-      ActiveRecord::Base.logger.debug "Prefix is _#{JqueryTmplRails.prefix}_"
-      puts "Prefix is _#{JqueryTmplRails.prefix}_"
       scope.logical_path.sub(JqueryTmplRails.prefix, "")
     end
   end

--- a/lib/jquery-tmpl-rails/jquery_template.rb
+++ b/lib/jquery-tmpl-rails/jquery_template.rb
@@ -6,32 +6,24 @@ require 'tilt'
 module JqueryTmplRails
   class JqueryTemplate < Tilt::Template
     include ActionView::Helpers::JavaScriptHelper
-
+    
     def self.default_mime_type
       'application/javascript'
     end
-
-    def prepare
-      @prefix = normalize_prefix(Rails.configuration.jquery_templates.prefix)
-    end
-
+    
     def evaluate(scope, locals, &block)
       %{jQuery.template("#{template_name(scope)}", "#{escape_javascript(data)}");}
     end
-
-    private
-
-    def normalize_prefix(prefix)
-      if prefix.length > 0
-        prefix = prefix[1, prefix.length - 1] if prefix.start_with?("/")
-        prefix += "/" unless prefix.end_with?("/")
-      end
-
-      prefix
+    
+    def prepare
     end
-
+    
+    private
+    
     def template_name(scope)
-      scope.logical_path.sub(@prefix, "")
+      ActiveRecord::Base.logger.debug "Prefix is _#{JqueryTmplRails.prefix}_"
+      puts "Prefix is _#{JqueryTmplRails.prefix}_"
+      scope.logical_path.sub(JqueryTmplRails.prefix, "")
     end
   end
 end

--- a/lib/jquery-tmpl-rails/jquery_template.rb
+++ b/lib/jquery-tmpl-rails/jquery_template.rb
@@ -1,6 +1,7 @@
 require 'sprockets'
 require 'action_view'
 require 'action_view/helpers'
+require 'tilt'
 
 module JqueryTmplRails
   class JqueryTemplate < Tilt::Template


### PR DESCRIPTION
- Since your update didn't solve the issue of Rails not addind your gem to the assets path, I made my own correction and it seems that adding 'tilt' to the dependencies and requiring it on top of the file corrected it, so I suggest you take a look at my changes and feel free to merge.
- I couldn't manage to set the prefix correctly so I moved the prefix conf to a "configure" method and I added support for Regexp prefix.

Have a nice day

Yann
